### PR TITLE
Extend domain of hasNonLinkedIdentifier

### DIFF
--- a/acdh-schema.owl
+++ b/acdh-schema.owl
@@ -1886,7 +1886,7 @@ Example: CC-BY 4.0 - 884, CC0 1.0 - 44</rdfs:comment>
 
     <owl:DatatypeProperty rdf:about="https://vocabs.acdh.oeaw.ac.at/schema#hasNonLinkedIdentifier">
         <rdfs:subPropertyOf rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#hasLiteralIdentifier"/>
-        <rdfs:domain rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#ContainerOrPublicationOrReMe"/>
+        <rdfs:domain rdf:resource="https://vocabs.acdh.oeaw.ac.at/schema#Main"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="de">Eindeutige Identifikatoren, die von anderen Parteien ohne stabile URL oder URI vergeben wurden, z.B. eine vom Geldgeber vergebene Nummer, eine ID von einem anderen Veröffentlichungsort oder eine Inventarnummer.
 Sollte dem Muster prefix:identifier folgen, z.B. &quot;Österreichische Nationalbank Jubiläumsfond:16365&quot;.


### PR DESCRIPTION
Changed domain of `hasNonLinkedIdentifer` to `Main`, in order to include classes `Person`, `Organisation` and `Place`.